### PR TITLE
Bump trim version for security fix

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30780,7 +30780,14 @@ var main = /*#__PURE__*/function () {
               newReadability: newReadability,
               oldReadability: oldReadability,
               fileStatuses: fileStatuses
-            });
+            }); // Only post a comment if there are results from markdown files
+            // changed in this PR
+
+            if (!report.fileResults.length) {
+              _context.next = 27;
+              break;
+            }
+
             repository = context.payload.repository.full_name;
             commit = context.payload.pull_request.head.sha;
             body = reportToComment({
@@ -30788,7 +30795,7 @@ var main = /*#__PURE__*/function () {
               repository: repository,
               commit: commit
             });
-            _context.next = 26;
+            _context.next = 27;
             return upsertComment({
               client: client,
               context: context,
@@ -30797,7 +30804,7 @@ var main = /*#__PURE__*/function () {
               hiddenHeader: "<!-- ".concat(glob, "-code-coverage-assistant -->")
             });
 
-          case 26:
+          case 27:
           case "end":
             return _context.stop();
         }

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
         "tabWidth": 4,
         "singleQuote": true,
         "bracketSpacing": false
+    },
+    "resolutions": {
+        "text-readability/syllable/trim": "^0.0.3"
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -41,18 +41,23 @@ const main = async () => {
         fileStatuses,
     });
 
-    const repository = context.payload.repository.full_name;
-    const commit = context.payload.pull_request.head.sha;
-
-    const body = reportToComment({report, repository, commit});
-
-    await upsertComment({
-        client,
-        context,
-        prNumber: context.payload.pull_request.number,
-        body,
-        hiddenHeader: `<!-- ${glob}-code-coverage-assistant -->`,
-    });
+    // Only post a comment if there are results from markdown files
+    // changed in this PR
+    if(report.fileResults.length)
+    {
+        const repository = context.payload.repository.full_name;
+        const commit = context.payload.pull_request.head.sha;
+    
+        const body = reportToComment({report, repository, commit});
+    
+        await upsertComment({
+            client,
+            context,
+            prNumber: context.payload.pull_request.number,
+            body,
+            hiddenHeader: `<!-- ${glob}-code-coverage-assistant -->`,
+        });
+    }
 };
 
 main().catch((err) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4487,10 +4487,10 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+trim@0.0.1, trim@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
+  integrity sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==
 
 trough@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
This PR:
- Overrides the version of `trim` used by `text-readability/syllables` dependency, as `v0.0.1` has a ["high" severity alert](https://github.com/Rebilly/readability-reporter/security/dependabot/yarn.lock/trim/open)
- With this PR I noticed the reporter posts even if you don't change any relevant files, so  I've changed the comment logic so it only comments if there are file results for the PR