### PR TITLE
feat: Improve readability accuracy

### DIFF
--- a/src/readability.test.js
+++ b/src/readability.test.js
@@ -1,4 +1,4 @@
-import {averageObjectProperties} from './readability';
+import {averageObjectProperties, preprocessMarkdown} from './readability';
 
 describe('averageObjectProperties', () => {
     it('should correctly return the average result for each property in the objects', () => {
@@ -8,10 +8,90 @@ describe('averageObjectProperties', () => {
             {a: 0.7, b: 300},
         ];
         expect(averageObjectProperties(testObjects)).toMatchInlineSnapshot(`
-Object {
-  "a": 0.6,
-  "b": 200,
-}
+            Object {
+              "a": 0.6,
+              "b": 200,
+            }
+        `);
+    });
+});
+
+describe('markdown preprocessing', () => {
+    it('should strip headers', () => {
+        const stripped = preprocessMarkdown(
+            `
+Test 1.
+# Header 1
+## Header 2
+### Header 3
+Test 2.
+`
+        );
+
+        expect(stripped).toMatchInlineSnapshot(`
+            "Test 1.
+            Test 2.
+            "
+        `);
+    });
+
+    it('should remove list items with less than 4 words', () => {
+        const stripped = preprocessMarkdown(
+            `
+- This item has many words.
+- This item does too.
+- This one not.
+- Or this.
+- Deleted.
+- This item also has many words.
+`
+        );
+
+        expect(stripped).toMatchInlineSnapshot(`
+            "This item has many words.
+            This item does too.
+            This item also has many words.
+            "
+        `);
+    });
+
+    it('should remove directives/admonitions', () => {
+        const stripped = preprocessMarkdown(
+            `
+Test 1.
+
+:::warning Warning
+
+Admonition content.
+
+:::
+
+Test 2.`
+        );
+
+        expect(stripped).toMatchInlineSnapshot(`
+            "Test 1.
+            Admonition content.
+            Test 2.
+            "
+        `);
+    });
+
+    it('should remove image alt descriptions', () => {
+        const stripped = preprocessMarkdown(
+            `
+Test 1.
+
+Click the left button ![Left Button Icon](../path-to-left/button.png)
+
+Test 2.`
+        );
+
+        expect(stripped).toMatchInlineSnapshot(`
+"Test 1.
+Click the left button 
+Test 2.
+"
 `);
     });
 });


### PR DESCRIPTION
This PR addresses some feedback from @noon-dawg about the readability report.

It stops considering these 3 things as part of the document:
- Header text
- Image alt text.
- Admonition tags (`:::alert Alert!` etc)

The `dist` is meant to be committed as part of this PR :) 