### PR TITLE
fix: vite build asset paths

### DIFF
--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -4,6 +4,10 @@ import mkcert from 'vite-plugin-mkcert';
 
 export default defineConfig({
     root: './playground',
+    // Set the base path, without this vite will reference the js and asset
+    // files as "/etc/blah.js" which will break the page if hosted at a sub
+    // path such as www.example.com/lexi/
+    base: './',
     plugins: [vue(), mkcert()],
     server: {
         https: true,


### PR DESCRIPTION
Currently the playground doesnt work in github pages as the asset path is absolute, but the gh page url is relative.

