### PR TITLE
chore: update action name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Lexi
+name: Lexi readability report
 description: Report a readability score for Markdown files in your pull requests
 author: 'Rebilly Inc'
 branding:


### PR DESCRIPTION
Updates the action name to one that is available on the GHA marketplace, otherwise we cannot publish it.