### PR TITLE
ci(release): automate tag updates

### DIFF
--- a/.github/workflows/update-tags-post-release.yml
+++ b/.github/workflows/update-tags-post-release.yml
@@ -1,0 +1,19 @@
+# As per the GitHub recommendations, we should update
+# the major and minor tags (ie v1, v1.1) to point to the
+# latest release.
+# See: https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-tags-for-release-management
+name: Update major and minor tags post release
+
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  update-major-and-minor-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: haya14busa/action-update-semver@v1

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ For example: `yarn run:local:report ./test-data/old ./test-data/new`
     1. Set the title to the version number, for example `v1.0.0`.
     1. Click "Generate release notes" to automatically generate the description since the last release.
     1. Click "Publish release".
-1. The release will be published to the Marketplace, and a [workflow automatically](./.github/workflows/update-tags-post-release.yml) updates the major and minor tags.
+1. The release is published to the Marketplace, and a [workflow automatically](./.github/workflows/update-tags-post-release.yml) updates the major and minor tags.
 
 ## Playground
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,17 @@ To test the action locally, execute the `run:local:report` command. This reports
 
 For example: `yarn run:local:report ./test-data/old ./test-data/new`
 
+### Release process
+
+1. Merge all changes into the `main` branch.
+1. Create a new [GitHub release](https://github.com/Rebilly/lexi/releases/new):
+    1. The version number must follow [semantic versioning](https://semver.org/).
+    1. Enter the new tag in the release form, and choose "Create a new tag on publish". The tag must be prefixed with a `v`, for example `v1.0.0`.
+    1. Set the title to the version number, for example `v1.0.0`.
+    1. Click "Generate release notes" to automatically generate the description since the last release.
+    1. Click "Publish release".
+1. The release will be published to the Marketplace, and a [workflow automatically](./.github/workflows/update-tags-post-release.yml) updates the major and minor tags.
+
 ## Playground
 
 To experiment with this tool in your web browser, and get real-time readability metric data as you edit a Markdown file, try out the [playground](https://rebilly.github.io/lexi/).

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ For example: `yarn run:local:report ./test-data/old ./test-data/new`
 
 1. Merge all changes into the `main` branch.
 1. Create a new [GitHub release](https://github.com/Rebilly/lexi/releases/new):
-    1. The version number must follow [semantic versioning](https://semver.org/).
-    1. Enter the new tag in the release form, and choose "Create a new tag on publish". The tag must be prefixed with a `v`, for example `v1.0.0`.
+    1. Enter the new tag in the release form, and choose "Create a new tag on publish". The tag must be prefixed with a `v`, for example `v1.0.0`. \
+    The version number must follow [semantic versioning](https://semver.org/).
     1. Set the title to the version number, for example `v1.0.0`.
     1. Click "Generate release notes" to automatically generate the description since the last release.
     1. Click "Publish release".


### PR DESCRIPTION
closes #45 

This PR adds a workflow which runs on tag pushes and updates major and minor tags to follow the current patch tags.

See https://github.com/haya14busa/action-update-semver 