### PR TITLE
fix(playground): toggle text color

### DIFF
--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -2,7 +2,6 @@
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
   color-scheme: dark;
 }
@@ -10,6 +9,8 @@
 body {
   margin: 0;
   min-height: 100vh;
+  --r-text: rgba(255, 255, 255, 0.87);
+  color: var(--r-text);
 }
 
 body .r-toggle-switch-handle {


### PR DESCRIPTION
The toggle text colour must have changed at some point.

This PR overrides the text colour using the css property.

Before:
<img width="345" alt="image" src="https://github.com/Rebilly/lexi/assets/492636/42f717f7-5585-4a19-9848-3951c653f4cd">

After:
<img width="342" alt="image" src="https://github.com/Rebilly/lexi/assets/492636/2adab3b1-16b3-4ce7-9ad5-7e2e6fb87249">
