### PR TITLE
chore(deps): Bump node versions

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-            node-version: 18
+            node-version: 22
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,7 +12,7 @@ jobs:
             - name: Setup node
               uses: actions/setup-node@v4
               with:
-                  node-version: 18
+                  node-version: 22
             - name: Restore node_modules cache
               uses: actions/cache@v4
               with:
@@ -32,7 +32,7 @@ jobs:
             - name: Setup node
               uses: actions/setup-node@v4
               with:
-                  node-version: 18
+                  node-version: 22
             - name: Restore node_modules cache
               uses: actions/cache@v4
               with:
@@ -52,7 +52,7 @@ jobs:
             - name: Setup node
               uses: actions/setup-node@v4
               with:
-                  node-version: 18
+                  node-version: 22
             - name: Restore node_modules cache
               uses: actions/cache@v4
               with:
@@ -76,7 +76,7 @@ jobs:
             - name: Setup node
               uses: actions/setup-node@v4
               with:
-                  node-version: 18
+                  node-version: 22
             - name: Restore node_modules cache
               uses: actions/cache@v4
               with:

--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: A glob pattern matching a set of markdown files to run the readability tests on
     required: true
 runs:
-  using: node12
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
Fixes #313 

This PR:
- Bumps the action runner to `node20`.
  - This is the latest available: https://github.com/actions/runner/discussions/2704#discussioncomment-9515846
- Bumps the node versions used in our GHA workflows to the new 22 LTS.