### PR TITLE
fix(workflows): remove custom token

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -46,12 +46,13 @@ jobs:
     build:
         name: Commit build
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
         steps:
             - name: Checkout repo
               uses: actions/checkout@v6
               with:
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.MACHINE_USER_PAT }}
             - name: Setup node
               uses: actions/setup-node@v6
               with:


### PR DESCRIPTION
Removes the custom `secrets.MACHINE_USER_PAT` token to fallback on the default `GITHUB_TOKEN`.
This is a public repo, the secret isn't needed.